### PR TITLE
feat: add tool exploration feature with --tool-tickle flag

### DIFF
--- a/src/mcpeek/config.py
+++ b/src/mcpeek/config.py
@@ -108,6 +108,7 @@ class ConfigManager:
             'timeout': 30.0,
             'log_level': 'INFO',
             'discover': False,
+            'tool_tickle': False,
             'stdin': False,
         }
 
@@ -146,6 +147,7 @@ class ConfigManager:
         arg_mappings = {
             'endpoint': 'endpoint',
             'discover': 'discover',
+            'tool_tickle': 'tool_tickle',
             'tool': 'tool',
             'resource': 'resource',
             'input': 'input',
@@ -213,6 +215,7 @@ class ConfigManager:
         return {
             'verbosity': config.get('verbosity', 0),
             'discover': config.get('discover', False),
+            'tool_tickle': config.get('tool_tickle', False),
         }
 
     def get_execution_config(self, config: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/mcpeek/discovery.py
+++ b/src/mcpeek/discovery.py
@@ -1,6 +1,7 @@
 """Discovery engine for MCP endpoint capabilities."""
 
 import asyncio
+import re
 from typing import List, Dict, Any
 
 from .mcp_client import MCPClient
@@ -11,11 +12,15 @@ from .utils.helpers import validate_verbosity_level
 
 class DiscoveryEngine:
     """Discovers and catalogs MCP endpoint capabilities."""
+    
+    # Default regex pattern for safe tools to tickle
+    SAFE_TOOL_PATTERN = re.compile(r".*(list|status|help).*", re.IGNORECASE)
 
-    def __init__(self, client: MCPClient, verbosity: int = 0):
-        """Initialize discovery engine with client and verbosity level."""
+    def __init__(self, client: MCPClient, verbosity: int = 0, tool_tickle: bool = False):
+        """Initialize discovery engine with client, verbosity level, and tool exploration option."""
         self.client = client
         self.verbosity = validate_verbosity_level(verbosity)
+        self.tool_tickle = tool_tickle
         self.logger = get_logger()
 
     async def discover_endpoint(self) -> DiscoveryResult:
@@ -49,6 +54,17 @@ class DiscoveryEngine:
             if isinstance(prompts, Exception):
                 self.logger.warning(f"Failed to discover prompts: {prompts}")
                 prompts = []
+            
+            # Perform tool exploration if enabled
+            tool_exploration_results = None
+            if self.tool_tickle and tools and not isinstance(tools, Exception):
+                try:
+                    from typing import cast
+                    safe_tools = cast(List[ToolInfo], tools)
+                    tool_exploration_results = await self.explore_tools(safe_tools)
+                except Exception as e:
+                    self.logger.warning(f"Tool exploration failed: {e}")
+                    tool_exploration_results = {"error": str(e)}
 
             # Update server capabilities based on actual discovery results
             # Only build capabilities from successful discoveries (not exceptions)
@@ -79,7 +95,8 @@ class DiscoveryEngine:
                 prompts=final_prompts,
                 capabilities=discovered_capabilities,
                 verbosity_level=self.verbosity,
-                version_info=version_info
+                version_info=version_info,
+                tool_exploration=tool_exploration_results
             )
 
             self.logger.info(f"Discovery complete: {len(final_tools)} tools, {len(final_resources)} resources, {len(final_prompts)} prompts")
@@ -301,3 +318,83 @@ class DiscoveryEngine:
             lines.append("")
 
         return "\n".join(lines)
+
+    async def explore_tools(self, tools: List[ToolInfo]) -> Dict[str, Any]:
+        """Explore tools by actually calling safe ones."""
+        if not self.tool_tickle or not tools:
+            return {}
+        
+        self.logger.info(f"Starting tool exploration with {len(tools)} tools")
+        exploration_results = {}
+        
+        # Filter tools that match the safe pattern
+        safe_tools = self.filter_safe_tools(tools)
+        self.logger.info(f"Found {len(safe_tools)} safe tools to explore: {[tool.name for tool in safe_tools]}")
+        
+        # Execute safe tools in parallel with error handling
+        exploration_tasks = []
+        for tool in safe_tools:
+            task = asyncio.create_task(self._explore_single_tool(tool))
+            exploration_tasks.append(task)
+        
+        # Wait for all explorations to complete
+        results = await asyncio.gather(*exploration_tasks, return_exceptions=True)
+        
+        # Process results and handle exceptions
+        for i, result in enumerate(results):
+            tool_name = safe_tools[i].name
+            if isinstance(result, Exception):
+                self.logger.warning(f"Failed to explore tool {tool_name}: {result}")
+                exploration_results[tool_name] = {
+                    "status": "error",
+                    "error": str(result)
+                }
+            else:
+                exploration_results[tool_name] = result
+        
+        self.logger.info(f"Tool exploration complete: explored {len(exploration_results)} tools")
+        return exploration_results
+    
+    def filter_safe_tools(self, tools: List[ToolInfo]) -> List[ToolInfo]:
+        """Filter tools that match the safe pattern."""
+        safe_tools = []
+        for tool in tools:
+            if self.SAFE_TOOL_PATTERN.match(tool.name):
+                safe_tools.append(tool)
+                self.logger.debug(f"Tool {tool.name} matches safe pattern")
+            else:
+                self.logger.debug(f"Tool {tool.name} does not match safe pattern")
+        
+        return safe_tools
+    
+    async def _explore_single_tool(self, tool: ToolInfo) -> Dict[str, Any]:
+        """Explore a single tool by calling it with minimal/no parameters."""
+        try:
+            self.logger.debug(f"Exploring tool: {tool.name}")
+            
+            # Try to call the tool with no parameters first
+            # Most list/status/help tools should work without parameters
+            try:
+                result = await self.client.call_tool(tool.name, {})
+                return {
+                    "status": "success",
+                    "result": result,
+                    "called_with": {}
+                }
+            except Exception as e:
+                # If calling with no parameters fails, we could try to analyze
+                # the tool schema and provide minimal required parameters
+                # For now, just report the failure
+                self.logger.debug(f"Tool {tool.name} failed with empty parameters: {e}")
+                return {
+                    "status": "failed_empty_params",
+                    "error": str(e),
+                    "called_with": {}
+                }
+                
+        except Exception as e:
+            self.logger.error(f"Unexpected error exploring tool {tool.name}: {e}")
+            return {
+                "status": "error",
+                "error": str(e)
+            }

--- a/src/mcpeek/formatters/base.py
+++ b/src/mcpeek/formatters/base.py
@@ -59,6 +59,7 @@ class DiscoveryResult:
     capabilities: Dict[str, Any]
     verbosity_level: int = 0
     version_info: Optional[Dict[str, Any]] = None
+    tool_exploration: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
         if not isinstance(self.tools, list):

--- a/src/mcpeek/formatters/json.py
+++ b/src/mcpeek/formatters/json.py
@@ -34,6 +34,10 @@ class JSONFormatter(BaseFormatter):
         # Include version information if available
         if result.version_info:
             output["version_info"] = result.version_info
+            
+        # Include tool exploration results if available
+        if result.tool_exploration:
+            output["tool_exploration"] = result.tool_exploration
 
         return self._format_json(output)
 

--- a/test_tool_tickle.py
+++ b/test_tool_tickle.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Simple test for the tool tickle functionality.
+This tests the core logic without requiring an actual MCP server.
+"""
+
+import sys
+import os
+
+# Add src to path for testing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from mcpeek.discovery import DiscoveryEngine
+from mcpeek.formatters.base import ToolInfo
+import re
+
+
+def test_safe_tool_pattern():
+    """Test that the regex pattern correctly identifies safe tools."""
+    pattern = DiscoveryEngine.SAFE_TOOL_PATTERN
+    
+    # Tools that should match (safe)
+    safe_tools = [
+        "list_files",
+        "get_status", 
+        "help_command",
+        "list_users",
+        "show_status",
+        "help",
+        "status",
+        "list",
+        "filesystem_list",
+        "system_status_check",
+        "get_help_info"
+    ]
+    
+    # Tools that should NOT match (potentially unsafe)
+    unsafe_tools = [
+        "delete_file",
+        "create_user", 
+        "execute_command",
+        "write_data",
+        "update_config",
+        "remove_entry",
+        "modify_settings"
+    ]
+    
+    print("Testing safe tool pattern matching...")
+    
+    # Test safe tools
+    for tool in safe_tools:
+        if pattern.match(tool):
+            print(f"✓ '{tool}' correctly identified as safe")
+        else:
+            print(f"✗ '{tool}' incorrectly identified as unsafe")
+            return False
+    
+    # Test unsafe tools  
+    for tool in unsafe_tools:
+        if not pattern.match(tool):
+            print(f"✓ '{tool}' correctly identified as unsafe")
+        else:
+            print(f"✗ '{tool}' incorrectly identified as safe")
+            return False
+    
+    return True
+
+
+def test_filter_safe_tools():
+    """Test the filter_safe_tools method."""
+    # Create mock discovery engine
+    class MockClient:
+        pass
+    
+    discovery = DiscoveryEngine(MockClient(), verbosity=0, tool_tickle=True)
+    
+    # Create test tools
+    test_tools = [
+        ToolInfo(name="list_files", description="List files"),
+        ToolInfo(name="delete_file", description="Delete a file"),
+        ToolInfo(name="get_status", description="Get system status"),
+        ToolInfo(name="create_user", description="Create new user"),
+        ToolInfo(name="help_command", description="Show help"),
+    ]
+    
+    # Filter safe tools
+    safe_tools = discovery.filter_safe_tools(test_tools)
+    safe_names = [tool.name for tool in safe_tools]
+    
+    expected_safe = ["list_files", "get_status", "help_command"]
+    
+    print("\nTesting tool filtering...")
+    print(f"Input tools: {[tool.name for tool in test_tools]}")
+    print(f"Filtered safe tools: {safe_names}")
+    print(f"Expected safe tools: {expected_safe}")
+    
+    if set(safe_names) == set(expected_safe):
+        print("✓ Tool filtering works correctly")
+        return True
+    else:
+        print("✗ Tool filtering failed")
+        return False
+
+
+def test_cli_argument_validation():
+    """Test CLI argument validation logic."""
+    from mcpeek.cli import MCPeekCLI
+    import argparse
+    
+    cli = MCPeekCLI()
+    
+    # Test that tool-tickle requires discover
+    print("\nTesting CLI validation...")
+    
+    # Create a mock namespace
+    args = argparse.Namespace()
+    args.endpoint = "http://test"
+    args.discover = False
+    args.tool_tickle = True
+    args.tool = None
+    args.resource = None
+    args.prompt = None
+    args.stdin = False
+    args.input = None
+    args.verbosity = 1
+    
+    try:
+        cli.validate_arguments(args)
+        print("✗ CLI validation failed - should have raised ValidationError")
+        return False
+    except Exception as e:
+        if "tool-tickle requires --discover mode" in str(e):
+            print("✓ CLI validation correctly requires --discover for --tool-tickle")
+            return True
+        else:
+            print(f"✗ CLI validation failed with unexpected error: {e}")
+            return False
+
+
+def main():
+    """Run all tests."""
+    print("Running Tool Tickle Feature Tests")
+    print("=" * 50)
+    
+    tests = [
+        test_safe_tool_pattern,
+        test_filter_safe_tools,
+        test_cli_argument_validation
+    ]
+    
+    passed = 0
+    failed = 0
+    
+    for test in tests:
+        try:
+            if test():
+                passed += 1
+                print(f"✓ {test.__name__} PASSED\n")
+            else:
+                failed += 1
+                print(f"✗ {test.__name__} FAILED\n")
+        except Exception as e:
+            failed += 1
+            print(f"✗ {test.__name__} FAILED with exception: {e}\n")
+    
+    print("=" * 50)
+    print(f"Test Results: {passed} passed, {failed} failed")
+    
+    if failed == 0:
+        print("🎉 All tests passed!")
+        return 0
+    else:
+        print("❌ Some tests failed")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the `--tool-tickle` feature requested in issue #4.

## Summary
- Adds `--tool-tickle` CLI argument that requires `--discover` mode
- Implements safe tool filtering using regex pattern `.*(list|status|help).*`
- Executes filtered tools during discovery with comprehensive error handling
- Extends output formatters to display exploration results

## Test Plan
- Manual code review completed
- Test file included demonstrating core functionality
- Follows existing codebase patterns and async conventions

Generated with [Claude Code](https://claude.ai/code)